### PR TITLE
Fix broken links about mpv

### DIFF
--- a/cli.html
+++ b/cli.html
@@ -869,7 +869,7 @@ before the dollar sign mpv uses to denote a format character.</p>
 mpv window title, the string &quot;${{mpv-version}}&quot; could be
 inserted inside your --title string.</p>
 <p class="last">A full list of the format codes mpv uses is available here:
-<a class="reference external" href="https://mpv.io/manual/master/#property-list">https://mpv.io/manual/master/#property-list</a></p>
+<a class="reference external" href="https://mpv.io/manual/stable/#property-list">https://mpv.io/manual/stable/#property-list</a></p>
 </dd>
 </dl>
 <p>Formatting variables available to use in <a class="reference internal" href="#cmdoption-t"><code class="xref std std-option docutils literal"><span class="pre">--title</span></code></a>:</p>

--- a/cli.html
+++ b/cli.html
@@ -869,7 +869,7 @@ before the dollar sign mpv uses to denote a format character.</p>
 mpv window title, the string &quot;${{mpv-version}}&quot; could be
 inserted inside your --title string.</p>
 <p class="last">A full list of the format codes mpv uses is available here:
-<a class="reference external" href="https://mpv.io/manual/stable/#property-expansion">https://mpv.io/manual/stable/#property-expansion</a></p>
+<a class="reference external" href="https://mpv.io/manual/master/#property-list">https://mpv.io/manual/master/#property-list</a></p>
 </dd>
 </dl>
 <p>Formatting variables available to use in <a class="reference internal" href="#cmdoption-t"><code class="xref std std-option docutils literal"><span class="pre">--title</span></code></a>:</p>

--- a/cli.html
+++ b/cli.html
@@ -869,7 +869,7 @@ before the dollar sign mpv uses to denote a format character.</p>
 mpv window title, the string &quot;${{mpv-version}}&quot; could be
 inserted inside your --title string.</p>
 <p class="last">A full list of the format codes mpv uses is available here:
-<a class="reference external" href="https://mpv.io/manual/stable/#property-list">https://mpv.io/manual/stable/#property-list</a></p>
+<a class="reference external" href="https://mpv.io/manual/master/#property-list">https://mpv.io/manual/master/#property-list</a></p>
 </dd>
 </dl>
 <p>Formatting variables available to use in <a class="reference internal" href="#cmdoption-t"><code class="xref std std-option docutils literal"><span class="pre">--title</span></code></a>:</p>

--- a/latest/cli.html
+++ b/latest/cli.html
@@ -879,7 +879,7 @@ before the dollar sign mpv uses to denote a format character.</p>
 mpv window title, the string &quot;${{mpv-version}}&quot; could be
 inserted inside your --title string.</p>
 <p class="last">A full list of the format codes mpv uses is available here:
-<a class="reference external" href="https://mpv.io/manual/stable/#property-expansion">https://mpv.io/manual/stable/#property-expansion</a></p>
+<a class="reference external" href="https://mpv.io/manual/master/#property-list">https://mpv.io/manual/master/#property-list</a></p>
 </dd>
 </dl>
 <p>Formatting variables available to use in <a class="reference internal" href="#cmdoption-t"><code class="xref std std-option docutils literal"><span class="pre">--title</span></code></a>:</p>


### PR DESCRIPTION
In command line usage, --title section links to wrong mpv docs about format codes. Fixed the link
This is my first pull request